### PR TITLE
Fixed constant mutation, removed errors when stumbling upon bools, minor renaming changes

### DIFF
--- a/Noisette/Obfuscation/RenameAnalyzer.cs
+++ b/Noisette/Obfuscation/RenameAnalyzer.cs
@@ -105,7 +105,7 @@ namespace NoisetteCore.Obfuscation
         {
             if (method.IsRuntimeSpecialName)
                 return false;
-            if (method.IsConstructor)
+            if (method.IsConstructor || method.IsStaticConstructor)
                 return false;
             if (method.DeclaringType.IsForwarder)
                 return false;

--- a/Noisette/Protection/Constant/ConstantProtection.cs
+++ b/Noisette/Protection/Constant/ConstantProtection.cs
@@ -62,7 +62,7 @@ namespace NoisetteCore.Protection.Constant
             var instr = method.Body.Instructions;
             for (int i = 0; i < instr.Count; i++)
             {
-                if (instr[i].IsLdcI4())
+                if (instr[i].OpCode == OpCodes.Ldc_I4)
                 {
                     ProtectIntegers(method, i);
                     i += 10;
@@ -352,7 +352,7 @@ namespace NoisetteCore.Protection.Constant
         public void ReplaceValue(MethodDef method, int i)
         {
             var instr = method.Body.Instructions;
-            if (!instr[i].IsLdcI4()) return;
+            if (instr[i].OpCode != OpCodes.Ldc_I4) return;
             var value = instr[i].GetLdcI4Value();
             if (value == 1)
                 CollatzConjecture(method, i);
@@ -395,7 +395,7 @@ namespace NoisetteCore.Protection.Constant
                 for (int index = 0; index < method.Body.Instructions.Count; index++)
                 {
                     Instruction instr = method.Body.Instructions[index];
-                    if (instr.IsLdcI4())
+                    if (instr.OpCode == OpCodes.Ldc_I4)
                     {
                         MethodDef proxy_method = CreateReturnMethodDef(instr.GetLdcI4Value(), method);
                         method.DeclaringType.Methods.Add(proxy_method);

--- a/Noisette/Protection/ConstantMelting/ConstantMeltingProtection.cs
+++ b/Noisette/Protection/ConstantMelting/ConstantMeltingProtection.cs
@@ -43,7 +43,7 @@ namespace NoisetteCore.Protection.ConstantMelting
                                 instr.Insert(i + (j + 1), Instruction.Create(OpCodes.Ldloc_S, new_local));
                             }
                         }
-                        if (instr[i].OpCode == OpCodes.Ldc_I4))
+                        if (instr[i].OpCode == OpCodes.Ldc_I4)
                         {
                             Random rn = new Random();
                             for (int j = 1; j < rn.Next(16); j++)

--- a/Noisette/Protection/ConstantMelting/ConstantMeltingProtection.cs
+++ b/Noisette/Protection/ConstantMelting/ConstantMeltingProtection.cs
@@ -43,7 +43,7 @@ namespace NoisetteCore.Protection.ConstantMelting
                                 instr.Insert(i + (j + 1), Instruction.Create(OpCodes.Ldloc_S, new_local));
                             }
                         }
-                        if (instr[i].IsLdcI4())
+                        if (instr[i].OpCode == OpCodes.Ldc_I4))
                         {
                             Random rn = new Random();
                             for (int j = 1; j < rn.Next(16); j++)

--- a/Noisette/Protection/Renaming/RenamingProtection.cs
+++ b/Noisette/Protection/Renaming/RenamingProtection.cs
@@ -2,7 +2,9 @@
 using NoisetteCore.Helper;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace NoisetteCore.Protection.Renaming
@@ -17,7 +19,7 @@ namespace NoisetteCore.Protection.Renaming
 
         public RenamingProtection(ModuleDefMD module)
         {
-            mscorlib = ModuleDefMD.Load(@"C:\Windows\Microsoft.NET\Framework\v2.0.50727\mscorlib.dll");
+            mscorlib = ModuleDefMD.Load(Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "mscorlib.dll"));
             UsedNames = new List<string>();
             _module = module;
         }


### PR DESCRIPTION
### Constant Melting:
Changed IsLdcI4() to OpCode == OpCodes.Ldc_I4 because Booleans are specified as Ldc_I4_1 and Ldc_I4_0 which gets included with the former statement.

### String Renaming:
Added checks for IsStaticConstructor, added dynamic framework path
